### PR TITLE
10 Fix redirections

### DIFF
--- a/_docs/build-process.md
+++ b/_docs/build-process.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+title: Build Process
+permalink: /docs/build-process
+---

--- a/_docs/components.md
+++ b/_docs/components.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+title: Components
+permalink: /docs/components
+---

--- a/_docs/deployment.md
+++ b/_docs/deployment.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+title: Deployment
+permalink: /docs/deployment
+---

--- a/_docs/usage.md
+++ b/_docs/usage.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+title: Usage
+permalink: /docs/usage
+---

--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -1,0 +1,15 @@
+---
+layout: default
+---
+{% assign ver = site.data.versions.last %}
+
+<script>
+window.onload = function(){
+  var docs_page = window.location.toString().split("/docs/")
+  const final_url = docs_page[0].concat("/docs/{{ ver }}/", docs_page[1])
+  window.location.replace(final_url)
+}
+</script>
+
+<h3>Redirecting to versioned documentattion</h3>
+<a href="{{ site.baseurl }}/docs/{{ ver }}" onclick="location.href = this.href + '/' + window.location.toString().split('/docs/')[1]; return false;"> Click here if you are not redirected. </a>

--- a/utils/create_docs/docs.rb
+++ b/utils/create_docs/docs.rb
@@ -54,7 +54,7 @@ module Docs
   def self.add_topic(topic_name:, doc_folder:, yaml_path:)
     name_pretty = topic_name.tr('-', ' ').split.map(&:capitalize).join(' ')
     FileUtils.cd(doc_folder, verbose: true) do
-      versions = Dir.glob('*')
+      versions = Dir.glob('*').select { |fn| File.directory?(fn) }
       versions.each do |version|
         FileUtils.cd(version, verbose: true) do
           first_file = Dir.glob('*').first
@@ -74,7 +74,7 @@ module Docs
   def self.remove_topic(topic_name:, doc_folder:, yaml_path:)
     file = "#{topic_name}.md"
     FileUtils.cd(doc_folder, verbose: true) do
-      versions = Dir.glob('*')
+      versions = Dir.glob('*').select { |fn| File.directory?(fn) }
       versions.each do |version|
         file_name = "#{version}/#{topic_name}.md"
         FireUtils.rm(file_name) if File.exist?(file_name)


### PR DESCRIPTION
Switch to not using the redirect-from plugin from Jekyll.  (I know the plugin was never used here, but only in Enceladus, but I want to have it said for the completeness.)

Using Javascript `location.replace` to redirect. This needs X dummy static pages created with layout redirect. It cannot be only one because there is a 1to1 relationship between permalinks.

Topic generator fixed to work, but does not currently create a redirect page.

Closes #10 